### PR TITLE
add accordion and wrapper snippets

### DIFF
--- a/snippets/language-mjml.cson
+++ b/snippets/language-mjml.cson
@@ -199,7 +199,7 @@
   'MJML Accordion':
     'prefix': 'accordion'
     'body': """
-      <mj-accordion>\n\t$1\n</mj-accordion-element>
+      <mj-accordion>\n\t$1\n</mj-accordion>
     """
 
   'MJML Accordion Element':

--- a/snippets/language-mjml.cson
+++ b/snippets/language-mjml.cson
@@ -177,7 +177,7 @@
     'body': """
       <mj-style>\n\t$1\n</mj-style>
     """
-    
+
   'MJML Carousel':
     'prefix': 'carousel'
     'body': """
@@ -188,6 +188,27 @@
     'prefix': 'carousel-image'
     'body': """
       <mj-carousel-image src="$1" />
+    """
+
+  'MJML Wrapper':
+    'prefix': 'wrapper'
+    'body': """
+      <mj-wrapper>\n\t$1\n</mj-wrapper>
+    """
+
+  'MJML Accordion':
+    'prefix': 'accordion'
+    'body': """
+      <mj-accordion>\n\t$1\n</mj-accordion-element>
+    """
+
+  'MJML Accordion Element':
+    'prefix': 'accordion-element'
+    'body': """
+      <mj-accordion-element $1>
+      \t<mj-accordion-title $2>\n\t\t$3\n</mj-accordion-title>
+      \t<mj-accordion-text $4>\n\t\t$5\n</mj-accordion-text>
+      </mj-accordion-element>
     """
 
 # MJML Template


### PR DESCRIPTION
The plugin wizard is back ! 
Added accordion and wrapper snippets. 

Not sure about the accordion one, an other option should be to add by default one accordion-element to the accordion snippet. What you think about it ? 

Waiting for your answer to update sublime text's snippets. 