### PR TITLE
Fix duplicate key error in snippets

### DIFF
--- a/snippets/language-mjml.cson
+++ b/snippets/language-mjml.cson
@@ -33,7 +33,7 @@
       <mjml>\n\t$1\n</mjml>
     """
 
-  'Mjml Column':
+  'Mjml Column (short)':
     'prefix': 'col'
     'body': """
       <mj-column>\n\t$1\n</mj-column>


### PR DESCRIPTION
Atom throws an error as soon as it loads this package, because it won't load duplicate keys in a snippets file. This could/might be fixed upstream, by allowing a simpler way to assign several prefixes to a single snippet (https://github.com/atom/snippets/issues/107).

In the meantime, the workaround is to duplicate as was done here, but name the snippets differently.