### PR TITLE
feat: remove snippets on embedded contexts

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,25 +3,22 @@
 
 Adds syntax highlighting and snippets to MJML files in Atom.
 
-This is a fork from language-html by atom
+This is a fork from `language-html` by atom.
 
 ## Installation
 
-```
+```sh
 apm install language-mjml
 ```
 
 ## Usage
 
-Template
+### Template
 
-Type `mjml-` and hit <Tab> to see the magic happen
+Type `mjml-` and hit <kbd>tab</kbd> to see the magic happen
 
-```
-mjml-<tab>
-
-# will expand to
-
+```html
+<!-- will expand to -->
 <mjml>
   <mj-head>
     <mj-title></mj-title>
@@ -37,23 +34,20 @@ mjml-<tab>
       </mj-section>
   </mj-body>
 </mjml>
-
 ```
 
-Components
+### Components
 
-type any mjml tag name, without `mj-` and hit <Tab> to see the magic happen
+Type any `mjml` tag name, without `mj-` and hit <kbd>tab</kbd> to see the magic happen. Ex: `body`
 
-```
-body<tab>
-
-# will expand to
-
+```html
+<!-- will expand to -->
 <mj-body>
 
 </mj-body>
-
 ```
+
+## Contributing
 
 Contributions are greatly appreciated. Please fork this repository and open a
 pull request to add snippets, make grammar tweaks, etc.

--- a/snippets/language-mjml.cson
+++ b/snippets/language-mjml.cson
@@ -1,200 +1,14 @@
-
-'.text.mjml.basic, .text.mjml, .text.mjml .meta.scope.between-tag-pair, .text.mjml .punctuation.tag.begin':
-
-# MJML elements
-
-  'Mjml Divider':
-    'prefix': 'divider'
-    'body': """
-      <mj-divider $1 />
-    """
-
-  'Mjml Invoice':
-    'prefix': 'invoice'
-    'body': """
-      <mj-invoice>\n\t$1\n</mj-invoice>
-    """
-
-  'Mjml Location':
-    'prefix': 'location'
-    'body': """
-      <mj-location address="$1"/>
-    """
-
-  'Mjml Table':
-    'prefix': 'table'
-    'body': """
-      <mj-table>\n\t$1\n</mj-table>
-    """
-
-  'Mjml':
-    'prefix': 'mjml'
-    'body': """
-      <mjml>\n\t$1\n</mjml>
-    """
-
-  'Mjml Column (short)':
-    'prefix': 'col'
-    'body': """
-      <mj-column>\n\t$1\n</mj-column>
-    """
-
-  'Mjml Column':
-    'prefix': 'column'
-    'body': """
-      <mj-column>\n\t$1\n</mj-column>
-    """
-
-  'Mjml Section':
-    'prefix': 'section'
-    'body': """
-      <mj-section>\n\t$1\n</mj-section>
-    """
-
-  'Mjml Raw':
-    'prefix': 'raw'
-    'body': """
-      <mj-raw>\n\t$1\n</mj-raw>
-    """
-
-  'Mjml Text':
-    'prefix': 'text'
-    'body': """
-      <mj-text>\n\t$1\n</mj-text>
-    """
-
-  'Mjml Button':
-    'prefix': 'button'
-    'body': """
-      <mj-button>\n\t$1\n</mj-button>
-    """
-
-  'Mjml Body':
-    'prefix': 'body'
-    'body': """
-      <mj-body>\n\t$1\n</mj-body>
-    """
-
-  'Mjml Social':
-    'prefix': 'social'
-    'body': """
-      <mj-social>\n\t$1\n</mj-social>
-    """
-
-  'Mjml Social Element':
-    'prefix': 'socialelement'
-    'body': """
-      <mj-social-element>\n\t$1\n</mj-social-element>
-    """
-
-  'MJML Image':
-    'prefix': 'image'
-    'body': """
-      <mj-image src="$1" />
-    """
-
-  'MJML Group':
-    'prefix': 'group'
-    'body': """
-      <mj-group>\n\t$1\n</mj-group>
-    """
-
-  'MJML Head':
-    'prefix': 'head'
-    'body': """
-      <mj-head>\n\t$1\n</mj-head>
-    """
-
-  'MJML Attributes':
-    'prefix': 'attributes'
-    'body': """
-      <mj-attributes>\n\t$1\n</mj-attributes>
-    """
-
-  'MJML Font':
-    'prefix': 'font'
-    'body': """
-      <mj-font name="$1" href="$2" />
-    """
-
-  'MJML Breakpoint':
-    'prefix': 'breakpoint'
-    'body': """
-      <mj-breakpoint width="$1" />
-    """
-
-  'MJML Title':
-    'prefix': 'title'
-    'body': """
-      <mj-title>$1</mj-title>
-    """
-
-  'MJML Preview':
-    'prefix': 'preview'
-    'body': """
-      <mj-preview>$1</mj-preview>
-    """
-
-  'Mjml Spacer':
-    'prefix': 'spacer'
-    'body': """
-      <mj-spacer $1 />
-    """
-
-  'Mjml Class':
-    'prefix': 'class'
-    'body': """
-      <mj-class name="$1" $2/>
-    """
-
-  'Mjml All':
-    'prefix': 'all'
-    'body': """
-      <mj-all $1 />
-    """
-
-  'MJML Hero':
-    'prefix': 'hero'
-    'body': """
-      <mj-hero>\n\t$1\n</mj-hero>
-    """
-
-  'MJML Include':
-    'prefix': 'include'
-    'body': """
-      <mj-include path="$1" />
-    """
-
-  'MJML Style':
-    'prefix': 'style'
-    'body': """
-      <mj-style>\n\t$1\n</mj-style>
-    """
-
-  'MJML Carousel':
-    'prefix': 'carousel'
-    'body': """
-      <mj-carousel>\n\t$1\n</mj-carousel>
-    """
-
-  'MJML Carousel Image':
-    'prefix': 'carousel-image'
-    'body': """
-      <mj-carousel-image src="$1" />
-    """
-
-  'MJML Wrapper':
-    'prefix': 'wrapper'
-    'body': """
-      <mj-wrapper>\n\t$1\n</mj-wrapper>
-    """
-
+# Important: When adding a new snippet,
+# there is a second section halfway down this file
+# where you need to null-out the snippet to prevent it from
+# appearing in tags or embedded contexts
+'.text.mjml':
+  # A
   'MJML Accordion':
     'prefix': 'accordion'
     'body': """
       <mj-accordion>\n\t$1\n</mj-accordion>
     """
-
   'MJML Accordion Element':
     'prefix': 'accordion-element'
     'body': """
@@ -203,21 +17,116 @@
       \t<mj-accordion-text> $2 </mj-accordion-text>
       </mj-accordion-element>
     """
-
-  'MJML Navbar':
-    'prefix': 'navbar'
+  'MJML All':
+    'prefix': 'all'
     'body': """
-      <mj-navbar>\n\t$1\n</mj-navbar>
+      <mj-all $1 />
     """
-
-  'MJML Navbar Link':
-    'prefix': 'navbarlink'
+  'MJML Attributes':
+    'prefix': 'attributes'
     'body': """
-      <mj-navbar-link>\n\t$1\n</mj-navbar-link>
+      <mj-attributes>\n\t$1\n</mj-attributes>
     """
-
-# MJML Template
-  'Basic MJML Template':
+  # B
+  'MJML Body':
+    'prefix': 'body'
+    'body': """
+      <mj-body>\n\t$1\n</mj-body>
+    """
+  'MJML Breakpoint':
+    'prefix': 'breakpoint'
+    'body': """
+      <mj-breakpoint width="$1" />
+    """
+  'MJML Button':
+    'prefix': 'button'
+    'body': """
+      <mj-button>\n\t$1\n</mj-button>
+    """
+  # C
+  'MJML Carousel':
+    'prefix': 'carousel'
+    'body': """
+      <mj-carousel>\n\t$1\n</mj-carousel>
+    """
+  'MJML Carousel Image':
+    'prefix': 'carousel-image'
+    'body': """
+      <mj-carousel-image src="$1" />
+    """
+  'MJML Class':
+    'prefix': 'class'
+    'body': """
+      <mj-class name="$1" $2/>
+    """
+  'MJML Column (short)':
+    'prefix': 'col'
+    'body': """
+      <mj-column>\n\t$1\n</mj-column>
+    """
+  'MJML Column':
+    'prefix': 'column'
+    'body': """
+      <mj-column>\n\t$1\n</mj-column>
+    """
+  # D
+  'MJML Divider':
+    'prefix': 'divider'
+    'body': """
+      <mj-divider $1 />
+    """
+  # F
+  'MJML Font':
+    'prefix': 'font'
+    'body': """
+      <mj-font name="$1" href="$2" />
+    """
+  # G
+  'MJML Group':
+    'prefix': 'group'
+    'body': """
+      <mj-group>\n\t$1\n</mj-group>
+    """
+  # H
+  'MJML Head':
+    'prefix': 'head'
+    'body': """
+      <mj-head>\n\t$1\n</mj-head>
+    """
+  'MJML Hero':
+    'prefix': 'hero'
+    'body': """
+      <mj-hero>\n\t$1\n</mj-hero>
+    """
+  # I
+  'MJML Image':
+    'prefix': 'image'
+    'body': """
+      <mj-image src="$1" />
+    """
+  'MJML Include':
+    'prefix': 'include'
+    'body': """
+      <mj-include path="$1" />
+    """
+  'MJML Invoice':
+    'prefix': 'invoice'
+    'body': """
+      <mj-invoice>\n\t$1\n</mj-invoice>
+    """
+  # L
+  'MJML Location':
+    'prefix': 'location'
+    'body': """
+      <mj-location address="$1"/>
+    """
+  # M
+  'MJML':
+    'prefix': 'mjml'
+    'body': """
+      <mjml>\n\t$1\n</mjml>
+    """
+  'MJML Basic Template':
     'prefix': 'mjml-'
     'body': """
       <mjml>
@@ -236,3 +145,166 @@
       \t</mj-body>
       </mjml>
     """
+  # N
+  'MJML Navbar':
+    'prefix': 'navbar'
+    'body': """
+      <mj-navbar>\n\t$1\n</mj-navbar>
+    """
+  'MJML Navbar Link':
+    'prefix': 'navbarlink'
+    'body': """
+      <mj-navbar-link>\n\t$1\n</mj-navbar-link>
+    """
+  # P
+  'MJML Preview':
+    'prefix': 'preview'
+    'body': """
+      <mj-preview>$1</mj-preview>
+    """
+  # R
+  'MJML Raw':
+    'prefix': 'raw'
+    'body': """
+      <mj-raw>\n\t$1\n</mj-raw>
+    """
+  # S  
+  'MJML Section':
+    'prefix': 'section'
+    'body': """
+      <mj-section>\n\t$1\n</mj-section>
+    """
+  'MJML Social':
+    'prefix': 'social'
+    'body': """
+      <mj-social>\n\t$1\n</mj-social>
+    """
+  'MJML Social Element':
+    'prefix': 'socialelement'
+    'body': """
+      <mj-social-element>\n\t$1\n</mj-social-element>
+    """
+  'MJML Spacer':
+    'prefix': 'spacer'
+    'body': """
+      <mj-spacer $1 />
+    """
+  'MJML Style':
+    'prefix': 'style'
+    'body': """
+      <mj-style>\n\t$1\n</mj-style>
+    """
+  # T
+  'MJML Table':
+    'prefix': 'table'
+    'body': """
+      <mj-table>\n\t$1\n</mj-table>
+    """
+  'MJML Text':
+    'prefix': 'text'
+    'body': """
+      <mj-text>\n\t$1\n</mj-text>
+    """
+  'MJML Title':
+    'prefix': 'title'
+    'body': """
+      <mj-title>$1</mj-title>
+    """
+  # W
+  'MJML Wrapper':
+    'prefix': 'wrapper'
+    'body': """
+      <mj-wrapper>\n\t$1\n</mj-wrapper>
+    """
+
+# These null out the snippets so the snippets are not available when in a tag or
+# in embedded contexts like <mj-style>
+'.text.mjml .meta.tag, .text.mjml .embedded':
+  # A
+  'MJML Accordion':
+    'prefix': 'accordion'
+  'MJML Accordion Element':
+    'prefix': 'accordion-element'
+  'MJML All':
+    'prefix': 'all'
+  'MJML Attributes':
+    'prefix': 'attributes'
+  # B
+  'MJML Body':
+    'prefix': 'body'
+  'MJML Breakpoint':
+    'prefix': 'breakpoint'
+  'MJML Button':
+    'prefix': 'button'
+  # C
+  'MJML Carousel':
+    'prefix': 'carousel'
+  'MJML Carousel Image':
+    'prefix': 'carousel-image'
+  'MJML Class':
+    'prefix': 'class'
+  'MJML Column (short)':
+    'prefix': 'col'
+  'MJML Column':
+    'prefix': 'column'
+  # D
+  'MJML Divider':
+    'prefix': 'divider'
+  # F
+  'MJML Font':
+    'prefix': 'font'
+  # G
+  'MJML Group':
+    'prefix': 'group'
+  # H
+  'MJML Head':
+    'prefix': 'head'
+  'MJML Hero':
+    'prefix': 'hero'
+  # I
+  'MJML Image':
+    'prefix': 'image'
+  'MJML Include':
+    'prefix': 'include'
+  'MJML Invoice':
+    'prefix': 'invoice'
+  # L
+  'MJML Location':
+    'prefix': 'location'
+  # M
+  'MJML':
+    'prefix': 'mjml'
+  'MJML Basic Template':
+    'prefix': 'mjml-'
+  # N
+  'MJML Navbar':
+    'prefix': 'navbar'
+  'MJML Navbar Link':
+    'prefix': 'navbarlink'
+  # P
+  'MJML Preview':
+    'prefix': 'preview'
+  # R
+  'MJML Raw':
+    'prefix': 'raw'
+  # S  
+  'MJML Section':
+    'prefix': 'section'
+  'MJML Social':
+    'prefix': 'social'
+  'MJML Social Element':
+    'prefix': 'socialelement'
+  'MJML Spacer':
+    'prefix': 'spacer'
+  'MJML Style':
+    'prefix': 'style'
+  # T
+  'MJML Table':
+    'prefix': 'table'
+  'MJML Text':
+    'prefix': 'text'
+  'MJML Title':
+    'prefix': 'title'
+  # W
+  'MJML Wrapper':
+    'prefix': 'wrapper'


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.

@ngarnier @iRyusa @kmcb777 this PR was created to avoid triggering snippets in unnecessary points, for example at the beginning of opening an attribute of an `mjml` tag or in autocompletion of properties in the `mj-style` tag.

I show you in detail, with this `gif`, what is currently happening _without_ this updated `snippets.cson` file:

![snippets-bad](https://user-images.githubusercontent.com/15775323/88206785-2268d600-cc4f-11ea-89f5-df402ad7da56.gif)

As you can see, as soon as I write the name of the `class` attribute, for example, the snippets curtain is triggered. But this **shouldn't be correct**.

Here is what should happen instead if this PR is merged. No triggering of snippets at **_unnecessary_** points.

![snippets-good](https://user-images.githubusercontent.com/15775323/88207613-5abce400-cc50-11ea-9e37-8fe7d93d689c.gif)

### Does this close any currently open issues?

Nope. This bug / feature is not registered on the [`Issues`](https://github.com/mjmlio/language-mjml/issues) tab .

### Any other comments?

Yep. I also updated the `README.md` file with the correct syntax highlight for code blocks, and slightly improved some description points.

These updates were also made in the [core](https://github.com/atom/language-html/blob/master/snippets/language-html.cson#L396) of the Atom `language-html` as this language is a fork of its. This gives the possibility in the future (if you want I can try to integrate it) to insert the support for [`Autocomplete+`](https://atom.io/packages/autocomplete-html) where for each `mjml` tag there is the possibility to autocomplete their attributes.

### Checklist

Check all those that are applicable and complete. Put an `x` between the brackets (without spaces).

-   [x] Merged with latest `master` branch